### PR TITLE
Update error messages from invalid sub_graph in model instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Keep it human-readable, your future self will thank you!
 
 ### Changed
 
+- New error messages for wrongs graphs.
+
 ### Removed
 
 ## 0.2.0

--- a/src/anemoi/models/layers/mapper.py
+++ b/src/anemoi/models/layers/mapper.py
@@ -134,8 +134,8 @@ class GraphEdgeMixin:
         trainable_size : int
             Trainable tensor size
         """
-        if edge_attributes is None:
-            raise ValueError("Edge attributes must be provided")
+        assert sub_graph, f"{self.__class__.__name__} needs a valid sub_graph to register edges."
+        assert edge_attributes is not None, "Edge attributes must be provided"
 
         edge_attr_tensor = torch.cat([sub_graph[attr] for attr in edge_attributes], axis=1)
 


### PR DESCRIPTION
This PR fixes issue #19. It displays an error message when a graph mapper is instantiated without a subgraph.
