### PR TITLE
Exclude pre-commit and readthedocs yaml from changelog ci

### DIFF
--- a/.github/workflows/changelog-pr-update.yml
+++ b/.github/workflows/changelog-pr-update.yml
@@ -2,6 +2,9 @@ name: Check Changelog Update on PR
 on:
   pull_request:
     types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    paths-ignore:
+      - .pre-commit-config.yaml
+      - .readthedocs.yaml
 jobs:
   Check-Changelog:
     name: Check Changelog Action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Keep it human-readable, your future self will thank you!
  - run downstream-ci only when src and tests folders have changed
  - New error messages for wrongs graphs.
  - Feature: Change model to be instantiatable in the interface, addressing [#28](https://github.com/ecmwf/anemoi-models/issues/28) through [#29](https://github.com/ecmwf/anemoi-models/pulls/29)
+ - CI: Remove pre-commit and readthedocs from changelog CI to have bots run smoothly [#30](https://github.com/ecmwf/anemoi-models/pulls/30)
 
 ### Removed
 


### PR DESCRIPTION
We have a few files that get automatic commits from bots and don't need changelog entries, namely:

- pre-commit hook config
- readthedocs config

This excludes the files from that CI.