### PR TITLE
fix: data indices import. typo documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ Keep it human-readable, your future self will thank you!
 
 ### Added
  - CI workflow to update the changelog on release
-
-- Remapper: Preprocessor for remapping one variable to multiple ones. Includes changes to the data indices since the remapper changes the number of variables.
+ - Remapper: Preprocessor for remapping one variable to multiple ones. Includes changes to the data indices since the remapper changes the number of variables.
 
 ### Changed
 

--- a/docs/modules/data_indices.rst
+++ b/docs/modules/data_indices.rst
@@ -53,7 +53,7 @@ remapper-preprocessor.
 
    data:
      remapped:
-       - d:
+       d:
          - "d_1"
          - "d_2"
 

--- a/src/anemoi/models/preprocessing/__init__.py
+++ b/src/anemoi/models/preprocessing/__init__.py
@@ -15,8 +15,7 @@ import torch
 from torch import Tensor
 from torch import nn
 
-if TYPE_CHECKING:
-    from anemoi.models.data_indices.collection import IndexCollection
+from anemoi.models.data_indices.collection import IndexCollection
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/anemoi/models/preprocessing/__init__.py
+++ b/src/anemoi/models/preprocessing/__init__.py
@@ -8,7 +8,6 @@
 #
 
 import logging
-from typing import TYPE_CHECKING
 from typing import Optional
 
 import torch

--- a/tests/data_indices/test_collection.py
+++ b/tests/data_indices/test_collection.py
@@ -19,12 +19,10 @@ def data_indices():
             "data": {
                 "forcing": ["x", "e"],
                 "diagnostic": ["z", "q"],
-                "remapped": [
-                    {
-                        "e": ["e_1", "e_2"],
-                        "d": ["d_1", "d_2"],
-                    }
-                ],
+                "remapped": {
+                    "e": ["e_1", "e_2"],
+                    "d": ["d_1", "d_2"],
+                },
             },
         },
     )

--- a/tests/preprocessing/test_preprocessor_imputer.py
+++ b/tests/preprocessing/test_preprocessor_imputer.py
@@ -26,7 +26,7 @@ def non_default_input_imputer():
                 "imputer": {"default": "none", "mean": ["y"], "maximum": ["x"], "none": ["z"], "minimum": ["q"]},
                 "forcing": ["z", "q"],
                 "diagnostic": ["other"],
-                "remapped": [],
+                "remapped": {},
             },
         },
     )

--- a/tests/preprocessing/test_preprocessor_normalizer.py
+++ b/tests/preprocessing/test_preprocessor_normalizer.py
@@ -25,7 +25,7 @@ def input_normalizer():
                 "normalizer": {"default": "mean-std", "min-max": ["x"], "max": ["y"], "none": ["z"], "mean-std": ["q"]},
                 "forcing": ["z", "q"],
                 "diagnostic": ["other"],
-                "remapped": [],
+                "remapped": {},
             },
         },
     )

--- a/tests/preprocessing/test_preprocessor_remapper.py
+++ b/tests/preprocessing/test_preprocessor_remapper.py
@@ -28,11 +28,9 @@ def input_remapper():
                 },
                 "forcing": ["z", "q"],
                 "diagnostic": ["other"],
-                "remapped": [
-                    {
-                        "d": ["cos_d", "sin_d"],
-                    }
-                ],
+                "remapped": {
+                    "d": ["cos_d", "sin_d"],
+                },
             },
         },
     )


### PR DESCRIPTION
Fix: import of package in init-function of preprocessors only if type_casting fails. 
Tests: remapped variables need to be dictionary
Typo: correction of typo in documentation.

<!-- readthedocs-preview anemoi-models start -->
----
📚 Documentation preview 📚: https://anemoi-models--34.org.readthedocs.build/en/34/

<!-- readthedocs-preview anemoi-models end -->