### PR TITLE
Feature/mapper chunking

### DIFF
--- a/src/anemoi/models/distributed/khop_edges.py
+++ b/src/anemoi/models/distributed/khop_edges.py
@@ -83,13 +83,11 @@ def sort_edges_1hop(
 
     return edge_attr, edge_index, [], []
 
+
 def sort_edges_1hop_chunks(
-    num_nodes: Union[int, tuple[int, int]],
-    edge_attr: Tensor,
-    edge_index: Adj,
-    num_chunks: int
+    num_nodes: Union[int, tuple[int, int]], edge_attr: Tensor, edge_index: Adj, num_chunks: int
 ) -> tuple[list[Tensor], list[Adj]]:
-    """Rearanges edges into 1 hop neighbourhood chunks. 
+    """Rearanges edges into 1 hop neighbourhood chunks.
 
     Parameters
     ----------
@@ -109,7 +107,7 @@ def sort_edges_1hop_chunks(
     """
     if isinstance(num_nodes, int):
         node_chunks = torch.arange(num_nodes, device=edge_index.device).tensor_split(num_chunks)
-    else: 
+    else:
         nodes_src = torch.arange(num_nodes[0], device=edge_index.device)
         node_chunks = torch.arange(num_nodes[1], device=edge_index.device).tensor_split(num_chunks)
 
@@ -127,5 +125,5 @@ def sort_edges_1hop_chunks(
             )
         edge_index_list.append(edge_index_chunk)
         edge_attr_list.append(edge_attr_chunk)
-    
+
     return edge_attr_list, edge_index_list

--- a/src/anemoi/models/distributed/khop_edges.py
+++ b/src/anemoi/models/distributed/khop_edges.py
@@ -74,29 +74,58 @@ def sort_edges_1hop(
     if mgroup:
         num_chunks = dist.get_world_size(group=mgroup)
 
-        if isinstance(num_nodes, int):
-            node_chunks = torch.arange(num_nodes, device=edge_index.device).tensor_split(num_chunks)
-        else:
-            nodes_src = torch.arange(num_nodes[0], device=edge_index.device)
-            node_chunks = torch.arange(num_nodes[1], device=edge_index.device).tensor_split(num_chunks)
+        edge_attr_list, edge_index_list = sort_edges_1hop_chunks(num_nodes, edge_attr, edge_index, num_chunks)
 
-        edge_index_list = []
-        edge_attr_list = []
-        for node_chunk in node_chunks:
-            if isinstance(num_nodes, int):
-                edge_attr_chunk, edge_index_chunk = get_k_hop_edges(node_chunk, edge_attr, edge_index)
-            else:
-                edge_index_chunk, edge_attr_chunk = bipartite_subgraph(
-                    (nodes_src, node_chunk),
-                    edge_index,
-                    edge_attr,
-                    size=(num_nodes[0], num_nodes[1]),
-                )
-            edge_index_list.append(edge_index_chunk)
-            edge_attr_list.append(edge_attr_chunk)
         edge_index_shapes = [x.shape for x in edge_index_list]
         edge_attr_shapes = [x.shape for x in edge_attr_list]
 
         return torch.cat(edge_attr_list, dim=0), torch.cat(edge_index_list, dim=1), edge_attr_shapes, edge_index_shapes
 
     return edge_attr, edge_index, [], []
+
+def sort_edges_1hop_chunks(
+    num_nodes: Union[int, tuple[int, int]],
+    edge_attr: Tensor,
+    edge_index: Adj,
+    num_chunks: int
+) -> tuple[list[Tensor], list[Adj]]:
+    """Rearanges edges into 1 hop neighbourhood chunks. 
+
+    Parameters
+    ----------
+    num_nodes : Union[int, tuple[int, int]]
+        Number of (target) nodes in Graph, tuple for bipartite graph
+    edge_attr : Tensor
+        edge attributes
+    edge_index : Adj
+        edge index
+    num_chunks : int
+        number of chunks used if mgroup is None
+
+    Returns
+    -------
+    tuple[list[Tensor], list[Adj]]
+        list of sorted edge attribute chunks, list of sorted edge_index chunks
+    """
+    if isinstance(num_nodes, int):
+        node_chunks = torch.arange(num_nodes, device=edge_index.device).tensor_split(num_chunks)
+    else: 
+        nodes_src = torch.arange(num_nodes[0], device=edge_index.device)
+        node_chunks = torch.arange(num_nodes[1], device=edge_index.device).tensor_split(num_chunks)
+
+    edge_index_list = []
+    edge_attr_list = []
+    for node_chunk in node_chunks:
+        if isinstance(num_nodes, int):
+            edge_attr_chunk, edge_index_chunk = get_k_hop_edges(node_chunk, edge_attr, edge_index)
+        else:
+            edge_index_chunk, edge_attr_chunk = bipartite_subgraph(
+                (nodes_src, node_chunk),
+                edge_index,
+                edge_attr,
+                size=(num_nodes[0], num_nodes[1]),
+            )
+        edge_index_list.append(edge_index_chunk)
+        edge_attr_list.append(edge_attr_chunk)
+    
+    return edge_attr_list, edge_index_list

--- a/src/anemoi/models/distributed/khop_edges.py
+++ b/src/anemoi/models/distributed/khop_edges.py
@@ -46,7 +46,7 @@ def get_k_hop_edges(nodes: Tensor, edge_attr: Tensor, edge_index: Adj, num_hops:
     return edge_attr[mask_to_index(edge_mask_k)], edge_index_k
 
 
-def sort_edges_1hop(
+def sort_edges_1hop_sharding(
     num_nodes: Union[int, tuple[int, int]],
     edge_attr: Tensor,
     edge_index: Adj,

--- a/src/anemoi/models/layers/block.py
+++ b/src/anemoi/models/layers/block.py
@@ -464,7 +464,6 @@ class GraphTransformerMapperBlock(GraphTransformerBaseBlock):
         )
 
         self.layer_norm2 = nn.LayerNorm(in_channels)
-        # self.cache = {"num_nodes": None, "num_edges": None, "batch_size": None, "chunks": None}
 
     def forward(
         self,

--- a/src/anemoi/models/layers/block.py
+++ b/src/anemoi/models/layers/block.py
@@ -495,7 +495,7 @@ class GraphTransformerMapperBlock(GraphTransformerBaseBlock):
         num_chunks = self.num_chunks if self.training else 4
 
         # split 1-hop edges into chunks, compute attention and aggregate 
-        if self.num_chunks > 1:
+        if num_chunks > 1:
             edge_attr_list, edge_index_list = sort_edges_1hop_chunks(num_nodes=size, edge_attr=edges, edge_index=edge_index, num_chunks=num_chunks) 
             for i in range(num_chunks):
                 out1 = self.conv(query=query, key=key, value=value, edge_attr=edge_attr_list[i], edge_index=edge_index_list[i], size=size)    

--- a/src/anemoi/models/layers/mapper.py
+++ b/src/anemoi/models/layers/mapper.py
@@ -23,7 +23,7 @@ from torch_geometric.typing import PairTensor
 
 from anemoi.models.distributed.graph import gather_tensor
 from anemoi.models.distributed.graph import shard_tensor
-from anemoi.models.distributed.khop_edges import sort_edges_1hop
+from anemoi.models.distributed.khop_edges import sort_edges_1hop_sharding
 from anemoi.models.distributed.shapes import change_channels_in_shape
 from anemoi.models.distributed.shapes import get_shape_shards
 from anemoi.models.layers.block import GraphConvMapperBlock
@@ -484,7 +484,7 @@ class GNNBaseMapper(GraphEdgeMixin, BaseMapper):
     def prepare_edges(self, size, batch_size, model_comm_group=None):
         edge_attr = self.trainable(self.edge_attr, batch_size)
         edge_index = self._expand_edges(self.edge_index_base, self.edge_inc, batch_size)
-        edge_attr, edge_index, shapes_edge_attr, shapes_edge_idx = sort_edges_1hop(
+        edge_attr, edge_index, shapes_edge_attr, shapes_edge_idx = sort_edges_1hop_sharding(
             size, edge_attr, edge_index, model_comm_group
         )
 

--- a/src/anemoi/models/layers/processor.py
+++ b/src/anemoi/models/layers/processor.py
@@ -18,7 +18,7 @@ from torch.utils.checkpoint import checkpoint
 from torch_geometric.data import HeteroData
 
 from anemoi.models.distributed.graph import shard_tensor
-from anemoi.models.distributed.khop_edges import sort_edges_1hop
+from anemoi.models.distributed.khop_edges import sort_edges_1hop_sharding
 from anemoi.models.distributed.shapes import change_channels_in_shape
 from anemoi.models.distributed.shapes import get_shape_shards
 from anemoi.models.layers.chunk import GNNProcessorChunk
@@ -231,7 +231,7 @@ class GNNProcessor(GraphEdgeMixin, BaseProcessor):
         edge_attr = self.trainable(self.edge_attr, batch_size)
         edge_index = self._expand_edges(self.edge_index_base, self.edge_inc, batch_size)
         target_nodes = sum(x[0] for x in shape_nodes)
-        edge_attr, edge_index, shapes_edge_attr, shapes_edge_idx = sort_edges_1hop(
+        edge_attr, edge_index, shapes_edge_attr, shapes_edge_idx = sort_edges_1hop_sharding(
             target_nodes,
             edge_attr,
             edge_index,


### PR DESCRIPTION
## Describe your changes
This PR adds a chunking strategy for the GraphTransformerMapperBlock to reduce peak memory usage during inference. 

During inference, the max memory usage is dominated by large peaks in the the encoder and decoder. Chunking the edges and computing the GraphTransformer forward pass sequentially nicely flattens these peaks without significant increases in runtime. The following projection MLPs are also computed sequentially in (node) chunks.  
Here are some results for a single-gpu, 240h-leadtime inference run on n320, hidden grid o48: 

| num_chunks | Peak Memory usage (GB) | Time (s) |
|------------|------------------------|----------|
| 1          | 33.45                  | 159.13   |
| 2          | 29.81                  | 159.45   |
| 4          | 24.85                  | 160.77   |
| 8          | 22.91                  | 160.84   |
| 16         | 22.08                  | 164.38   |

The number of chunks during inference is handled by an environment variable `ANEMOI_NUM_CHUNKS_INFERENCE` which seems to be the only practical solution currently as we are currently not able to pass options to the model during inference. It falls back to no chunking i.e. `num_chunks=1` if not set. 
I am happy about any suggestions/alternative solutions. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update*

*I am not sure how/where to document the usage of the environment variable, the goal would be to find a better long-time solution at some point

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation and docstrings to reflect the changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have ensured that the code is still pip-installable after the changes and runs
- [ ] I have not introduced new dependencies in the inference partion of the model*
- [x] I have ran this on single GPU
- [x] I have ran this on multi-GPU or multi-node
- [ ] I have ran this to work on LUMI (or made sure the changes work independently.)
- [ ] I have ran the Benchmark Profiler against the old version of the code

*technically the environment variable is a new dependency in inference

## Tag possible reviewers
@ssmmnn11 @JesperDramsch @theissenhelen @gmertes