### PR TITLE
Update encoder_processor_decoder.py

### DIFF
--- a/src/anemoi/models/models/encoder_processor_decoder.py
+++ b/src/anemoi/models/models/encoder_processor_decoder.py
@@ -108,7 +108,7 @@ class AnemoiModelEncProcDec(nn.Module):
         # Instantiation of model output bounding functions (e.g., to ensure outputs like TP are positive definite)
         self.boundings = nn.ModuleList(
             [
-                instantiate(cfg, name_to_index=self.data_indices.model.output.name_to_index)
+                instantiate(cfg, name_to_index=self.data_indices.internal_model.output.name_to_index)
                 for cfg in getattr(model_config.model, "bounding", [])
             ]
         )


### PR DESCRIPTION
There were recent changes in anemoi-models to introduce the remapper into anemoi-training https://github.com/ecmwf/anemoi-training/pull/17. These changes introduced an additional level of indexing:

from model to internal_model and model

from data to internal_data and data

These changes were not taken into account in the bounding feature PR. In this PR, we fix this.