### PR TITLE
Fix/Inference mode for Imputers

### DIFF
--- a/src/anemoi/models/preprocessing/imputer.py
+++ b/src/anemoi/models/preprocessing/imputer.py
@@ -109,7 +109,11 @@ class BaseImputer(BasePreprocessor, ABC):
         if not in_place:
             x = x.clone()
 
-        # Initilialize mask once
+        # Reset NaN locations outside of training for validation and inference.
+        if not self.training:
+            self.nan_locations = None
+
+        # Initilialize mask if not cached.
         if self.nan_locations is None:
             # The mask is only saved for the last two dimensions (grid, variable)
             idx = [slice(0, 1)] * (x.ndim - 2) + [slice(None), slice(None)]

--- a/tests/preprocessing/test_preprocessor_imputer.py
+++ b/tests/preprocessing/test_preprocessor_imputer.py
@@ -130,14 +130,17 @@ def default_constant_data():
     return base, expected
 
 
+fixture_combinations = (
+    ("default_constant_imputer", "default_constant_data"),
+    ("non_default_constant_imputer", "non_default_constant_data"),
+    ("default_input_imputer", "default_input_data"),
+    ("non_default_input_imputer", "non_default_input_data"),
+)
+
+
 @pytest.mark.parametrize(
     ("imputer_fixture", "data_fixture"),
-    [
-        ("default_constant_imputer", "default_constant_data"),
-        ("non_default_constant_imputer", "non_default_constant_data"),
-        ("default_input_imputer", "default_input_data"),
-        ("non_default_input_imputer", "non_default_input_data"),
-    ],
+    [fixture_combinations],
 )
 def test_imputer_not_inplace(imputer_fixture, data_fixture, request) -> None:
     """Check that the imputer does not modify the input tensor when in_place=False."""
@@ -150,12 +153,7 @@ def test_imputer_not_inplace(imputer_fixture, data_fixture, request) -> None:
 
 @pytest.mark.parametrize(
     ("imputer_fixture", "data_fixture"),
-    [
-        ("default_constant_imputer", "default_constant_data"),
-        ("non_default_constant_imputer", "non_default_constant_data"),
-        ("default_input_imputer", "default_input_data"),
-        ("non_default_input_imputer", "non_default_input_data"),
-    ],
+    [fixture_combinations],
 )
 def test_imputer_inplace(imputer_fixture, data_fixture, request) -> None:
     """Check that the imputer modifies the input tensor when in_place=True."""
@@ -169,12 +167,7 @@ def test_imputer_inplace(imputer_fixture, data_fixture, request) -> None:
 
 @pytest.mark.parametrize(
     ("imputer_fixture", "data_fixture"),
-    [
-        ("default_constant_imputer", "default_constant_data"),
-        ("non_default_constant_imputer", "non_default_constant_data"),
-        ("default_input_imputer", "default_input_data"),
-        ("non_default_input_imputer", "non_default_input_data"),
-    ],
+    [fixture_combinations],
 )
 def test_transform_with_nan(imputer_fixture, data_fixture, request):
     """Check that the imputer correctly transforms a tensor with NaNs."""
@@ -186,12 +179,7 @@ def test_transform_with_nan(imputer_fixture, data_fixture, request):
 
 @pytest.mark.parametrize(
     ("imputer_fixture", "data_fixture"),
-    [
-        ("default_constant_imputer", "default_constant_data"),
-        ("non_default_constant_imputer", "non_default_constant_data"),
-        ("default_input_imputer", "default_input_data"),
-        ("non_default_input_imputer", "non_default_input_data"),
-    ],
+    [fixture_combinations],
 )
 def test_transform_with_nan_small(imputer_fixture, data_fixture, request):
     """Check that the imputer correctly transforms a tensor with NaNs."""
@@ -211,12 +199,7 @@ def test_transform_with_nan_small(imputer_fixture, data_fixture, request):
 
 @pytest.mark.parametrize(
     ("imputer_fixture", "data_fixture"),
-    [
-        ("default_constant_imputer", "default_constant_data"),
-        ("non_default_constant_imputer", "non_default_constant_data"),
-        ("default_input_imputer", "default_input_data"),
-        ("non_default_input_imputer", "non_default_input_data"),
-    ],
+    [fixture_combinations],
 )
 def test_transform_with_nan_inference(imputer_fixture, data_fixture, request):
     """Check that the imputer correctly transforms a tensor with NaNs in inference."""
@@ -244,12 +227,7 @@ def test_transform_with_nan_inference(imputer_fixture, data_fixture, request):
 
 @pytest.mark.parametrize(
     ("imputer_fixture", "data_fixture"),
-    [
-        ("default_constant_imputer", "default_constant_data"),
-        ("non_default_constant_imputer", "non_default_constant_data"),
-        ("default_input_imputer", "default_input_data"),
-        ("non_default_input_imputer", "non_default_input_data"),
-    ],
+    [fixture_combinations],
 )
 def test_transform_noop(imputer_fixture, data_fixture, request):
     """Check that the imputer does not modify a tensor without NaNs."""
@@ -262,12 +240,7 @@ def test_transform_noop(imputer_fixture, data_fixture, request):
 
 @pytest.mark.parametrize(
     ("imputer_fixture", "data_fixture"),
-    [
-        ("default_constant_imputer", "default_constant_data"),
-        ("non_default_constant_imputer", "non_default_constant_data"),
-        ("default_input_imputer", "default_input_data"),
-        ("non_default_input_imputer", "non_default_input_data"),
-    ],
+    [fixture_combinations],
 )
 def test_inverse_transform(imputer_fixture, data_fixture, request):
     """Check that the imputer correctly inverts the transformation."""
@@ -281,12 +254,7 @@ def test_inverse_transform(imputer_fixture, data_fixture, request):
 
 @pytest.mark.parametrize(
     ("imputer_fixture", "data_fixture"),
-    [
-        ("default_constant_imputer", "default_constant_data"),
-        ("non_default_constant_imputer", "non_default_constant_data"),
-        ("default_input_imputer", "default_input_data"),
-        ("non_default_input_imputer", "non_default_input_data"),
-    ],
+    [fixture_combinations],
 )
 def test_mask_saving(imputer_fixture, data_fixture, request):
     """Check that the imputer saves the NaN mask correctly."""
@@ -299,12 +267,7 @@ def test_mask_saving(imputer_fixture, data_fixture, request):
 
 @pytest.mark.parametrize(
     ("imputer_fixture", "data_fixture"),
-    [
-        ("default_constant_imputer", "default_constant_data"),
-        ("non_default_constant_imputer", "non_default_constant_data"),
-        ("default_input_imputer", "default_input_data"),
-        ("non_default_input_imputer", "non_default_input_data"),
-    ],
+    [fixture_combinations],
 )
 def test_reuse_imputer(imputer_fixture, data_fixture, request):
     """Check that the imputer reuses the mask correctly on subsequent runs."""


### PR DESCRIPTION
This resets the `nan_locations` in the `BaseImputer` during non-training runs of the code.

Specifically, this enables changes in the dataset after training.