### PR TITLE
Triggers, messaging, release notes in changelog CI

### DIFF
--- a/.github/workflows/changelog-release-update.yml
+++ b/.github/workflows/changelog-release-update.yml
@@ -28,6 +28,7 @@ jobs:
       with:
         latest-version: ${{ github.event.release.tag_name }}
         heading-text: ${{ github.event.release.name }}
+        release-notes: ${{ github.event.release.body }}
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
1. Changes when the CI is run.

This avoids "bad runs" if a release fails, as it depends on a successful workflow run.

2. Copies the generated release note to the changelog

This intends to reduce merge conflicts due to individually updated changelogs.

3. Big red message in PR to merge

This adds a note to the PR message to not squash to help users perform the correct action.