### PR TITLE
Feature/reduce-decoder-mem-usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Keep it human-readable, your future self will thank you!
 - Update copyright notice
 - Fix `__version__` import in init
 - Fix missing copyrights [#71](https://github.com/ecmwf/anemoi-models/pull/71)
+- Reduced memory usage when using chunking in the mapper [#84](https://github.com/ecmwf/anemoi-models/pull/84)
 
 ### Removed
 

--- a/src/anemoi/models/layers/block.py
+++ b/src/anemoi/models/layers/block.py
@@ -512,8 +512,9 @@ class GraphTransformerMapperBlock(GraphTransformerBaseBlock):
             edge_attr_list, edge_index_list = sort_edges_1hop_chunks(
                 num_nodes=size, edge_attr=edges, edge_index=edge_index, num_chunks=num_chunks
             )
+            out=torch.zeros((x[1].shape[0], self.num_heads, self.out_channels_conv), device=x[1].device)
             for i in range(num_chunks):
-                out1 = self.conv(
+                out = self.conv(
                     query=query,
                     key=key,
                     value=value,
@@ -521,9 +522,6 @@ class GraphTransformerMapperBlock(GraphTransformerBaseBlock):
                     edge_index=edge_index_list[i],
                     size=size,
                 )
-                if i == 0:
-                    out = torch.zeros_like(out1, device=out1.device)
-                out = out + out1
         else:
             out = self.conv(query=query, key=key, value=value, edge_attr=edges, edge_index=edge_index, size=size)
 

--- a/src/anemoi/models/layers/block.py
+++ b/src/anemoi/models/layers/block.py
@@ -514,7 +514,7 @@ class GraphTransformerMapperBlock(GraphTransformerBaseBlock):
             )
             out=torch.zeros((x[1].shape[0], self.num_heads, self.out_channels_conv), device=x[1].device)
             for i in range(num_chunks):
-                out = self.conv(
+                out += self.conv(
                     query=query,
                     key=key,
                     value=value,

--- a/src/anemoi/models/layers/block.py
+++ b/src/anemoi/models/layers/block.py
@@ -512,7 +512,7 @@ class GraphTransformerMapperBlock(GraphTransformerBaseBlock):
             edge_attr_list, edge_index_list = sort_edges_1hop_chunks(
                 num_nodes=size, edge_attr=edges, edge_index=edge_index, num_chunks=num_chunks
             )
-            out=torch.zeros((x[1].shape[0], self.num_heads, self.out_channels_conv), device=x[1].device)
+            out = torch.zeros((x[1].shape[0], self.num_heads, self.out_channels_conv), device=x[1].device)
             for i in range(num_chunks):
                 out += self.conv(
                     query=query,


### PR DESCRIPTION
This change increases the memory saved from using chunking in the mapper. At the moment we use two arrays to accumulate chunks, this replaces it with a single array. At 9km this reduces peak memory usage by 6GB. 

Below I have pictures of memory usage during the chunking part of the decoder at 9km
### Before

<img width="483" alt="Screenshot 2024-11-21 at 13 55 24" src="https://github.com/user-attachments/assets/a1979e20-1533-4224-bfe8-ce0e75954384">


Notice the zig-zag pattern. This is from the 'out1' tensor being constantly created and freed each chunk.


### After
<img width="457" alt="Screenshot 2024-11-21 at 13 55 37" src="https://github.com/user-attachments/assets/c055f651-c3fa-4cb4-b02d-8743b8a89516">


Now the zig-zag pattern is gone and peak memory usage has decreased by 6GB
