### PR TITLE
Flexible normalization layers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ classifiers = [
 dynamic = [ "version" ]
 dependencies = [
   # Fix certain dependencies during development
-  "anemoi-training @ git+https://github.com/ecmwf/anemoi-training.git@25abf5e143a29d5931ccb4ac42a5f83c5cd26851",
   "anemoi-utils>=0.1.9",
   "einops>=0.6.1",
   "hydra-core>=1.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ classifiers = [
 
 dynamic = [ "version" ]
 dependencies = [
+  # Fix certain dependencies during development
+  "anemoi-training @ git+https://github.com/ecmwf/anemoi-training.git@25abf5e143a29d5931ccb4ac42a5f83c5cd26851",
   "anemoi-utils>=0.1.9",
   "einops>=0.6.1",
   "hydra-core>=1.3",

--- a/src/anemoi/models/layers/attention.py
+++ b/src/anemoi/models/layers/attention.py
@@ -25,10 +25,10 @@ except ImportError:
 else:
     _FLASH_ATTENTION_AVAILABLE = True
 
+from anemoi.utils.config import DotDict
+
 from anemoi.models.distributed.transformer import shard_heads
 from anemoi.models.distributed.transformer import shard_sequence
-
-from anemoi.utils.config import DotDict
 
 LOGGER = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ class MultiHeadSelfAttention(nn.Module):
         self.dropout_p = dropout_p
         self.is_causal = is_causal
 
-        linear=layer_kernels["Linear"]
+        linear = layer_kernels["Linear"]
         self.lin_qkv = linear(embed_dim, 3 * embed_dim, bias=bias)
         self.attention = attn_func
 

--- a/src/anemoi/models/layers/block.py
+++ b/src/anemoi/models/layers/block.py
@@ -13,7 +13,6 @@ import os
 from abc import ABC
 from abc import abstractmethod
 from typing import Optional
-from hydra.utils import instantiate
 
 import einops
 import torch

--- a/src/anemoi/models/layers/block.py
+++ b/src/anemoi/models/layers/block.py
@@ -16,6 +16,7 @@ from typing import Optional
 
 import einops
 import torch
+from anemoi.utils.config import DotDict
 from torch import Tensor
 from torch import nn
 from torch.distributed.distributed_c10d import ProcessGroup
@@ -32,7 +33,6 @@ from anemoi.models.layers.attention import MultiHeadSelfAttention
 from anemoi.models.layers.conv import GraphConv
 from anemoi.models.layers.conv import GraphTransformerConv
 from anemoi.models.layers.mlp import MLP
-from anemoi.utils.config import DotDict
 
 LOGGER = logging.getLogger(__name__)
 
@@ -100,9 +100,7 @@ class TransformerProcessorBlock(BaseBlock):
         )
 
     def forward(
-        self, x: Tensor, shapes: list, batch_size: int,
-        model_comm_group: Optional[ProcessGroup] = None,
-        **kwargs
+        self, x: Tensor, shapes: list, batch_size: int, model_comm_group: Optional[ProcessGroup] = None, **kwargs
     ) -> Tensor:
         # Need to be out of place for gradient propagation
         x = x + self.attention(self.layer_norm1(x), shapes, batch_size, model_comm_group=model_comm_group)
@@ -348,8 +346,8 @@ class GraphTransformerBaseBlock(BaseBlock, ABC):
 
         self.num_chunks = num_chunks
 
-        linear=layer_kernels['Linear']
-        layerNorm=layer_kernels['LayerNorm']
+        linear = layer_kernels["Linear"]
+        layerNorm = layer_kernels["LayerNorm"]
         self.lin_key = linear(in_channels, num_heads * self.out_channels_conv)
         self.lin_query = linear(in_channels, num_heads * self.out_channels_conv)
         self.lin_value = linear(in_channels, num_heads * self.out_channels_conv)
@@ -627,8 +625,7 @@ class GraphTransformerProcessorBlock(GraphTransformerBaseBlock):
             bias=bias,
             activation=activation,
             num_chunks=num_chunks,
-            update_src_nodes=update_src_nodes
-            **kwargs,
+            update_src_nodes=update_src_nodes**kwargs,
         )
 
     def forward(

--- a/src/anemoi/models/layers/chunk.py
+++ b/src/anemoi/models/layers/chunk.py
@@ -24,6 +24,7 @@ from anemoi.models.layers.block import GraphConvProcessorBlock
 from anemoi.models.layers.block import GraphTransformerProcessorBlock
 from anemoi.models.layers.block import TransformerProcessorBlock
 from anemoi.models.layers.mlp import MLP
+from anemoi.utils.config import DotDict
 
 LOGGER = logging.getLogger(__name__)
 
@@ -37,6 +38,7 @@ class BaseProcessorChunk(nn.Module, ABC):
         num_layers: int,
         *args,
         activation: str = "GELU",
+        layer_norm: Optional[dict] = None,
         **kwargs,
     ) -> None:
         """Initialize BaseProcessorChunk."""
@@ -71,11 +73,11 @@ class TransformerProcessorChunk(BaseProcessorChunk):
         num_channels: int,
         num_layers: int,
         window_size: int,
+        layer_kernels: DotDict,
         num_heads: int = 16,
         mlp_hidden_ratio: int = 4,
         activation: str = "GELU",
         dropout_p: float = 0.0,
-        layer_norm: Optional[dict] = None,
     ) -> None:
         """Initialize TransformerProcessor.
 
@@ -85,6 +87,11 @@ class TransformerProcessorChunk(BaseProcessorChunk):
             Number of channels
         num_layers : int
             Number of layers
+        window_size: int,
+            1/2 size of shifted window for attention computation
+        layer_kernels : DotDict
+            A dict of layer implementations e.g. layer_kernels['Linear'] = "torch.nn.Linear"
+            Defined in config/models/<model>.yaml
         num_heads: int
             Number of heads to use, default 16
         mlp_hidden_ratio: int
@@ -104,7 +111,7 @@ class TransformerProcessorChunk(BaseProcessorChunk):
             activation=activation,
             window_size=window_size,
             dropout_p=dropout_p,
-            layer_norm=layer_norm,
+            layer_kernels=layer_kernels
         )
 
     def forward(
@@ -127,6 +134,7 @@ class GNNProcessorChunk(BaseProcessorChunk):
         self,
         num_channels: int,
         num_layers: int,
+        layer_kernels: DotDict,
         mlp_extra_layers: int = 0,
         activation: str = "SiLU",
         edge_dim: Optional[int] = None,
@@ -139,6 +147,9 @@ class GNNProcessorChunk(BaseProcessorChunk):
             Channels of the message passing blocks.
         num_layers : int
             Number of message passing blocks.
+        layer_kernels : DotDict
+            A dict of layer implementations e.g. layer_kernels['Linear'] = "torch.nn.Linear"
+            Defined in config/models/<model>.yaml
         mlp_extra_layers : int, optional
             Extra num_layers in MLP, by default 0
         activation : str, optional
@@ -166,6 +177,7 @@ class GNNProcessorChunk(BaseProcessorChunk):
             num_channels,
             mlp_extra_layers=mlp_extra_layers,
             activation=activation,
+            layer_kernels=layer_kernels,
         )
 
     def forward(
@@ -194,6 +206,7 @@ class GraphTransformerProcessorChunk(BaseProcessorChunk):
         self,
         num_channels: int,
         num_layers: int,
+        layer_kernels: DotDict,
         num_heads: int = 16,
         mlp_hidden_ratio: int = 4,
         activation: str = "GELU",
@@ -207,6 +220,9 @@ class GraphTransformerProcessorChunk(BaseProcessorChunk):
             Number of channels.
         num_layers : int
             Number of layers.
+        layer_kernels : DotDict
+            A dict of layer implementations e.g. layer_kernels['Linear'] = "torch.nn.Linear"
+            Defined in config/models/<model>.yaml
         num_heads: int
             Number of heads to use, default 16
         mlp_hidden_ratio: int
@@ -226,6 +242,7 @@ class GraphTransformerProcessorChunk(BaseProcessorChunk):
             num_heads=num_heads,
             edge_dim=edge_dim,
             activation=activation,
+            layer_kernels=layer_kernels,
         )
 
     def forward(

--- a/src/anemoi/models/layers/chunk.py
+++ b/src/anemoi/models/layers/chunk.py
@@ -120,10 +120,9 @@ class TransformerProcessorChunk(BaseProcessorChunk):
         shapes: list,
         batch_size: int,
         model_comm_group: Optional[ProcessGroup] = None,
-        **kwargs,
     ) -> Tensor:
         for i in range(self.num_layers):
-            x = self.blocks[i](x, shapes, batch_size, model_comm_group=model_comm_group, **kwargs)
+            x = self.blocks[i](x, shapes, batch_size, model_comm_group=model_comm_group)
 
         return (x,)  # return tuple for consistency with other processors
 

--- a/src/anemoi/models/layers/chunk.py
+++ b/src/anemoi/models/layers/chunk.py
@@ -75,6 +75,7 @@ class TransformerProcessorChunk(BaseProcessorChunk):
         mlp_hidden_ratio: int = 4,
         activation: str = "GELU",
         dropout_p: float = 0.0,
+        layer_norm: Optional[dict] = None,
     ) -> None:
         """Initialize TransformerProcessor.
 
@@ -103,13 +104,18 @@ class TransformerProcessorChunk(BaseProcessorChunk):
             activation=activation,
             window_size=window_size,
             dropout_p=dropout_p,
+            layer_norm=layer_norm,
         )
 
     def forward(
-        self, x: Tensor, shapes: list, batch_size: int, model_comm_group: Optional[ProcessGroup] = None
+        self, x: Tensor, shapes: list, batch_size: int,
+        model_comm_group: Optional[ProcessGroup] = None,
+        **kwargs,
     ) -> Tensor:
         for i in range(self.num_layers):
-            x = self.blocks[i](x, shapes, batch_size, model_comm_group=model_comm_group)
+            x = self.blocks[i](x, shapes, batch_size,
+                               model_comm_group=model_comm_group,
+                               **kwargs)
 
         return (x,)  # return tuple for consistency with other processors
 

--- a/src/anemoi/models/layers/chunk.py
+++ b/src/anemoi/models/layers/chunk.py
@@ -13,6 +13,7 @@ from abc import ABC
 from abc import abstractmethod
 from typing import Optional
 
+from anemoi.utils.config import DotDict
 from torch import Tensor
 from torch import nn
 from torch.distributed.distributed_c10d import ProcessGroup
@@ -24,7 +25,6 @@ from anemoi.models.layers.block import GraphConvProcessorBlock
 from anemoi.models.layers.block import GraphTransformerProcessorBlock
 from anemoi.models.layers.block import TransformerProcessorBlock
 from anemoi.models.layers.mlp import MLP
-from anemoi.utils.config import DotDict
 
 LOGGER = logging.getLogger(__name__)
 
@@ -111,18 +111,19 @@ class TransformerProcessorChunk(BaseProcessorChunk):
             activation=activation,
             window_size=window_size,
             dropout_p=dropout_p,
-            layer_kernels=layer_kernels
+            layer_kernels=layer_kernels,
         )
 
     def forward(
-        self, x: Tensor, shapes: list, batch_size: int,
+        self,
+        x: Tensor,
+        shapes: list,
+        batch_size: int,
         model_comm_group: Optional[ProcessGroup] = None,
         **kwargs,
     ) -> Tensor:
         for i in range(self.num_layers):
-            x = self.blocks[i](x, shapes, batch_size,
-                               model_comm_group=model_comm_group,
-                               **kwargs)
+            x = self.blocks[i](x, shapes, batch_size, model_comm_group=model_comm_group, **kwargs)
 
         return (x,)  # return tuple for consistency with other processors
 

--- a/src/anemoi/models/layers/chunk.py
+++ b/src/anemoi/models/layers/chunk.py
@@ -72,8 +72,8 @@ class TransformerProcessorChunk(BaseProcessorChunk):
         self,
         num_channels: int,
         num_layers: int,
-        window_size: int,
         layer_kernels: DotDict,
+        window_size: int,
         num_heads: int = 16,
         mlp_hidden_ratio: int = 4,
         activation: str = "GELU",
@@ -87,11 +87,11 @@ class TransformerProcessorChunk(BaseProcessorChunk):
             Number of channels
         num_layers : int
             Number of layers
-        window_size: int,
-            1/2 size of shifted window for attention computation
         layer_kernels : DotDict
             A dict of layer implementations e.g. layer_kernels['Linear'] = "torch.nn.Linear"
             Defined in config/models/<model>.yaml
+        window_size: int,
+            1/2 size of shifted window for attention computation
         num_heads: int
             Number of heads to use, default 16
         mlp_hidden_ratio: int
@@ -110,8 +110,8 @@ class TransformerProcessorChunk(BaseProcessorChunk):
             num_heads=num_heads,
             activation=activation,
             window_size=window_size,
-            dropout_p=dropout_p,
             layer_kernels=layer_kernels,
+            dropout_p=dropout_p,
         )
 
     def forward(
@@ -165,6 +165,7 @@ class GNNProcessorChunk(BaseProcessorChunk):
                 in_features=edge_dim,
                 hidden_dim=num_channels,
                 out_features=num_channels,
+                layer_kernels=layer_kernels,
                 n_extra_layers=mlp_extra_layers,
                 activation=activation,
             )
@@ -175,9 +176,9 @@ class GNNProcessorChunk(BaseProcessorChunk):
             GraphConvProcessorBlock,
             num_channels,
             num_channels,
+            layer_kernels=layer_kernels,
             mlp_extra_layers=mlp_extra_layers,
             activation=activation,
-            layer_kernels=layer_kernels,
         )
 
     def forward(
@@ -239,10 +240,10 @@ class GraphTransformerProcessorChunk(BaseProcessorChunk):
             in_channels=num_channels,
             hidden_dim=mlp_hidden_ratio * num_channels,
             out_channels=num_channels,
-            num_heads=num_heads,
             edge_dim=edge_dim,
-            activation=activation,
+            num_heads=num_heads,
             layer_kernels=layer_kernels,
+            activation=activation,
         )
 
     def forward(

--- a/src/anemoi/models/layers/conv.py
+++ b/src/anemoi/models/layers/conv.py
@@ -11,6 +11,7 @@
 from typing import Optional
 
 import torch
+from anemoi.utils.config import DotDict
 from torch import Tensor
 from torch.nn.functional import dropout
 from torch_geometric.nn.conv import MessagePassing
@@ -31,6 +32,7 @@ class GraphConv(MessagePassing):
         self,
         in_channels: int,
         out_channels: int,
+        layer_kernels: DotDict,
         mlp_extra_layers: int = 0,
         activation: str = "SiLU",
         **kwargs,
@@ -43,6 +45,9 @@ class GraphConv(MessagePassing):
             Number of input channels.
         out_channels : int
             Number of output channels.
+        layer_kernels : DotDict
+            A dict of layer implementations e.g. layer_kernels['Linear'] = "torch.nn.Linear"
+            Defined in config/models/<model>.yaml
         mlp_extra_layers : int, optional
             Extra layers in MLP, by default 0
         activation : str, optional
@@ -54,6 +59,7 @@ class GraphConv(MessagePassing):
             3 * in_channels,
             out_channels,
             out_channels,
+            layer_kernels=layer_kernels,
             n_extra_layers=mlp_extra_layers,
             activation=activation,
         )

--- a/src/anemoi/models/layers/mapper.py
+++ b/src/anemoi/models/layers/mapper.py
@@ -227,7 +227,6 @@ class GraphTransformerBaseMapper(GraphEdgeMixin, BaseMapper):
             num_chunks=num_chunks,
             cpu_offload=cpu_offload,
             activation=activation,
-            layer_kernels=layer_kernels,
         )
 
         # Linear = layer_kernels.get("Linear", torch.nn.Linear)
@@ -453,6 +452,7 @@ class GNNBaseMapper(GraphEdgeMixin, BaseMapper):
         sub_graph_edge_attributes: Optional[list[str]] = None,
         src_grid_size: int = 0,
         dst_grid_size: int = 0,
+        layer_kernels: DotDict = None,
     ) -> None:
         """Initialize GNNBaseMapper.
 
@@ -476,6 +476,9 @@ class GNNBaseMapper(GraphEdgeMixin, BaseMapper):
             Whether to offload processing to CPU, by default False
         out_channels_dst : Optional[int], optional
             Output channels of the destination node, by default None
+        layer_kernels : DotDict
+            A dict of layer implementations e.g. layer_kernels['Linear'] = "torch.nn.Linear"
+            Defined in config/models/<model>.yaml
         """
         super().__init__(
             in_channels_src,
@@ -493,6 +496,7 @@ class GNNBaseMapper(GraphEdgeMixin, BaseMapper):
             in_features=self.edge_dim,
             hidden_dim=hidden_dim,
             out_features=hidden_dim,
+            layer_kernels=layer_kernels,
             n_extra_layers=mlp_extra_layers,
             activation=activation,
         )
@@ -557,6 +561,7 @@ class GNNForwardMapper(ForwardMapperPreProcessMixin, GNNBaseMapper):
         sub_graph_edge_attributes: Optional[list[str]] = None,
         src_grid_size: int = 0,
         dst_grid_size: int = 0,
+        layer_kernels: DotDict = None,
     ) -> None:
         """Initialize GNNForwardMapper.
 
@@ -580,6 +585,9 @@ class GNNForwardMapper(ForwardMapperPreProcessMixin, GNNBaseMapper):
             Whether to offload processing to CPU, by default False
         out_channels_dst : Optional[int], optional
             Output channels of the destination node, by default None
+        layer_kernels : DotDict
+            A dict of layer implementations e.g. layer_kernels['Linear'] = "torch.nn.Linear"
+            Defined in config/models/<model>.yaml
         """
         super().__init__(
             in_channels_src,
@@ -595,11 +603,13 @@ class GNNForwardMapper(ForwardMapperPreProcessMixin, GNNBaseMapper):
             sub_graph_edge_attributes=sub_graph_edge_attributes,
             src_grid_size=src_grid_size,
             dst_grid_size=dst_grid_size,
+            layer_kernels=layer_kernels,
         )
 
         self.proc = GraphConvMapperBlock(
             hidden_dim,
             hidden_dim,
+            layer_kernels=layer_kernels,
             mlp_extra_layers=mlp_extra_layers,
             activation=activation,
             update_src_nodes=True,
@@ -612,6 +622,7 @@ class GNNForwardMapper(ForwardMapperPreProcessMixin, GNNBaseMapper):
             in_features=in_channels_src,
             hidden_dim=hidden_dim,
             out_features=hidden_dim,
+            layer_kernels=layer_kernels,
             n_extra_layers=mlp_extra_layers,
             activation=activation,
         )
@@ -620,6 +631,7 @@ class GNNForwardMapper(ForwardMapperPreProcessMixin, GNNBaseMapper):
             in_features=in_channels_dst,
             hidden_dim=hidden_dim,
             out_features=hidden_dim,
+            layer_kernels=layer_kernels,
             n_extra_layers=mlp_extra_layers,
             activation=activation,
         )
@@ -643,6 +655,7 @@ class GNNBackwardMapper(BackwardMapperPostProcessMixin, GNNBaseMapper):
         sub_graph_edge_attributes: Optional[list[str]] = None,
         src_grid_size: int = 0,
         dst_grid_size: int = 0,
+        layer_kernels: DotDict = None,
     ) -> None:
         """Initialize GNNBackwardMapper.
 
@@ -666,6 +679,9 @@ class GNNBackwardMapper(BackwardMapperPostProcessMixin, GNNBaseMapper):
             Whether to offload processing to CPU, by default False
         out_channels_dst : Optional[int], optional
             Output channels of the destination node, by default None
+        layer_kernels : DotDict
+            A dict of layer implementations e.g. layer_kernels['Linear'] = "torch.nn.Linear"
+            Defined in config/models/<model>.yaml
         """
         super().__init__(
             in_channels_src,
@@ -681,11 +697,13 @@ class GNNBackwardMapper(BackwardMapperPostProcessMixin, GNNBaseMapper):
             sub_graph_edge_attributes=sub_graph_edge_attributes,
             src_grid_size=src_grid_size,
             dst_grid_size=dst_grid_size,
+            layer_kernels=layer_kernels,
         )
 
         self.proc = GraphConvMapperBlock(
             hidden_dim,
             hidden_dim,
+            layer_kernels=layer_kernels,
             mlp_extra_layers=mlp_extra_layers,
             activation=activation,
             update_src_nodes=False,
@@ -698,6 +716,7 @@ class GNNBackwardMapper(BackwardMapperPostProcessMixin, GNNBaseMapper):
             in_features=self.hidden_dim,
             hidden_dim=self.hidden_dim,
             out_features=self.out_channels_dst,
+            layer_kernels=layer_kernels,
             n_extra_layers=mlp_extra_layers,
             activation=self.activation,
             layer_norm=False,

--- a/src/anemoi/models/layers/mapper.py
+++ b/src/anemoi/models/layers/mapper.py
@@ -14,6 +14,7 @@ from typing import Optional
 
 import numpy as np
 import torch
+from anemoi.utils.config import DotDict
 from torch import Tensor
 from torch import nn
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import offload_wrapper
@@ -31,7 +32,6 @@ from anemoi.models.layers.block import GraphConvMapperBlock
 from anemoi.models.layers.block import GraphTransformerMapperBlock
 from anemoi.models.layers.graph import TrainableTensor
 from anemoi.models.layers.mlp import MLP
-from anemoi.utils.config import DotDict
 
 LOGGER = logging.getLogger(__name__)
 
@@ -229,8 +229,8 @@ class GraphTransformerBaseMapper(GraphEdgeMixin, BaseMapper):
             activation=activation,
             layer_kernels=layer_kernels,
         )
-        
-        #Linear = layer_kernels.get("Linear", torch.nn.Linear)
+
+        # Linear = layer_kernels.get("Linear", torch.nn.Linear)
         Linear = layer_kernels["Linear"]
 
         self._register_edges(sub_graph, sub_graph_edge_attributes, src_grid_size, dst_grid_size, trainable_size)
@@ -245,7 +245,7 @@ class GraphTransformerBaseMapper(GraphEdgeMixin, BaseMapper):
             edge_dim=self.edge_dim,
             activation=activation,
             num_chunks=num_chunks,
-            layer_kernels=layer_kernels
+            layer_kernels=layer_kernels,
         )
 
         self.offload_layers(cpu_offload)

--- a/src/anemoi/models/layers/mlp.py
+++ b/src/anemoi/models/layers/mlp.py
@@ -11,11 +11,10 @@
 import logging
 
 import torch
+from anemoi.utils.config import DotDict
 from torch import nn
 
-from anemoi.models.layers.normalization import AutocastLayerNorm
 from anemoi.models.layers.utils import CheckpointWrapper
-from anemoi.utils.config import DotDict
 
 LOGGER = logging.getLogger(__name__)
 
@@ -73,7 +72,7 @@ class MLP(nn.Module):
 
         Linear = layer_kernels["Linear"]
         LayerNorm = layer_kernels["LayerNorm"]
-        
+
         try:
             act_func = getattr(nn, activation)
         except AttributeError as ae:

--- a/src/anemoi/models/layers/mlp.py
+++ b/src/anemoi/models/layers/mlp.py
@@ -89,7 +89,7 @@ class MLP(nn.Module):
             mlp1.append(act_func())
 
         if layer_norm:
-            mlp1.append(LayerNorm(out_features).as_type(out_features))
+            mlp1.append(LayerNorm(normalized_shape=out_features))
 
         self.model = CheckpointWrapper(mlp1) if checkpoints else mlp1
 

--- a/src/anemoi/models/layers/mlp.py
+++ b/src/anemoi/models/layers/mlp.py
@@ -15,6 +15,7 @@ from torch import nn
 
 from anemoi.models.layers.normalization import AutocastLayerNorm
 from anemoi.models.layers.utils import CheckpointWrapper
+from anemoi.utils.config import DotDict
 
 LOGGER = logging.getLogger(__name__)
 
@@ -27,6 +28,7 @@ class MLP(nn.Module):
         in_features: int,
         hidden_dim: int,
         out_features: int,
+        layer_kernels: DotDict,
         n_extra_layers: int = 0,
         activation: str = "SiLU",
         final_activation: bool = False,
@@ -43,6 +45,9 @@ class MLP(nn.Module):
             Hidden dimensions
         out_features : int
             Number of output features
+        layer_kernels : DotDict
+            A dict of layer implementations e.g. layer_kernels['Linear'] = "torch.nn.Linear"
+            Defined in config/models/<model>.yaml
         n_extra_layers : int, optional
             Number of extra layers in MLP, by default 0
         activation : str, optional
@@ -65,23 +70,27 @@ class MLP(nn.Module):
             If activation function is not supported
         """
         super().__init__()
+
+        Linear = layer_kernels["Linear"]
+        LayerNorm = layer_kernels["LayerNorm"]
+        
         try:
             act_func = getattr(nn, activation)
         except AttributeError as ae:
             LOGGER.error("Activation function %s not supported", activation)
             raise RuntimeError from ae
 
-        mlp1 = nn.Sequential(nn.Linear(in_features, hidden_dim), act_func())
+        mlp1 = nn.Sequential(Linear(in_features, hidden_dim), act_func())
         for _ in range(n_extra_layers + 1):
-            mlp1.append(nn.Linear(hidden_dim, hidden_dim))
+            mlp1.append(Linear(hidden_dim, hidden_dim))
             mlp1.append(act_func())
-        mlp1.append(nn.Linear(hidden_dim, out_features))
+        mlp1.append(Linear(hidden_dim, out_features))
 
         if final_activation:
             mlp1.append(act_func())
 
         if layer_norm:
-            mlp1.append(AutocastLayerNorm(out_features))
+            mlp1.append(LayerNorm(out_features).as_type(out_features))
 
         self.model = CheckpointWrapper(mlp1) if checkpoints else mlp1
 

--- a/src/anemoi/models/layers/mlp.py
+++ b/src/anemoi/models/layers/mlp.py
@@ -13,7 +13,7 @@ import logging
 import torch
 from torch import nn
 
-from anemoi.models.layers.utils import AutocastLayerNorm
+from anemoi.models.layers.normalization import AutocastLayerNorm
 from anemoi.models.layers.utils import CheckpointWrapper
 
 LOGGER = logging.getLogger(__name__)

--- a/src/anemoi/models/layers/normalization.py
+++ b/src/anemoi/models/layers/normalization.py
@@ -1,0 +1,31 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from __future__ import annotations
+
+from abc import ABC
+from abc import abstractmethod
+
+import torch
+from torch import nn
+
+
+class AutocastLayerNorm(nn.LayerNorm):
+    """LayerNorm that casts the output back to the input type."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Forward with explicit autocast back to the input type.
+
+        This casts the output to (b)float16 (instead of float32) when we run in mixed
+        precision.
+        """
+        return super().forward(x).type_as(x)

--- a/src/anemoi/models/layers/normalization.py
+++ b/src/anemoi/models/layers/normalization.py
@@ -9,7 +9,6 @@
 
 from __future__ import annotations
 
-
 from torch import nn
 
 

--- a/src/anemoi/models/layers/normalization.py
+++ b/src/anemoi/models/layers/normalization.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+from torch import Tensor
 from torch import nn
 
 

--- a/src/anemoi/models/layers/normalization.py
+++ b/src/anemoi/models/layers/normalization.py
@@ -9,10 +9,7 @@
 
 from __future__ import annotations
 
-from abc import ABC
-from abc import abstractmethod
 
-import torch
 from torch import nn
 
 

--- a/src/anemoi/models/layers/processor.py
+++ b/src/anemoi/models/layers/processor.py
@@ -27,6 +27,7 @@ from anemoi.models.layers.chunk import GraphTransformerProcessorChunk
 from anemoi.models.layers.chunk import TransformerProcessorChunk
 from anemoi.models.layers.graph import TrainableTensor
 from anemoi.models.layers.mapper import GraphEdgeMixin
+from anemoi.utils.config import DotDict
 
 
 class BaseProcessor(nn.Module, ABC):
@@ -88,6 +89,7 @@ class TransformerProcessor(BaseProcessor):
     def __init__(
         self,
         num_layers: int,
+        layer_kernels: DotDict,
         *args,
         window_size: Optional[int] = None,
         num_channels: int = 128,
@@ -97,7 +99,6 @@ class TransformerProcessor(BaseProcessor):
         num_heads: int = 16,
         mlp_hidden_ratio: int = 4,
         dropout_p: float = 0.1,
-        layer_norm: Optional[dict] = None,
         **kwargs,
     ) -> None:
         """Initialize TransformerProcessor.
@@ -106,6 +107,9 @@ class TransformerProcessor(BaseProcessor):
         ----------
         num_layers : int
             Number of num_layers
+        layer_kernels : DotDict
+            A dict of layer implementations e.g. layer_kernels['Linear'] = "torch.nn.Linear"
+            Defined in config/models/<model>.yaml
         window_size: int,
             1/2 size of shifted window for attention computation
         num_channels : int
@@ -128,6 +132,7 @@ class TransformerProcessor(BaseProcessor):
             cpu_offload=cpu_offload,
             num_heads=num_heads,
             mlp_hidden_ratio=mlp_hidden_ratio,
+            #layer_kernels=layer_kernels,
         )
 
         self.build_layers(
@@ -139,7 +144,7 @@ class TransformerProcessor(BaseProcessor):
             window_size=window_size,
             activation=activation,
             dropout_p=dropout_p,
-            layer_norm=layer_norm,
+            layer_kernels=layer_kernels,
         )
 
         self.offload_layers(cpu_offload)

--- a/src/anemoi/models/layers/processor.py
+++ b/src/anemoi/models/layers/processor.py
@@ -11,6 +11,7 @@
 from abc import ABC
 from typing import Optional
 
+from anemoi.utils.config import DotDict
 from torch import Tensor
 from torch import nn
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import offload_wrapper
@@ -27,7 +28,6 @@ from anemoi.models.layers.chunk import GraphTransformerProcessorChunk
 from anemoi.models.layers.chunk import TransformerProcessorChunk
 from anemoi.models.layers.graph import TrainableTensor
 from anemoi.models.layers.mapper import GraphEdgeMixin
-from anemoi.utils.config import DotDict
 
 
 class BaseProcessor(nn.Module, ABC):
@@ -132,7 +132,7 @@ class TransformerProcessor(BaseProcessor):
             cpu_offload=cpu_offload,
             num_heads=num_heads,
             mlp_hidden_ratio=mlp_hidden_ratio,
-            #layer_kernels=layer_kernels,
+            # layer_kernels=layer_kernels,
         )
 
         self.build_layers(

--- a/src/anemoi/models/layers/processor.py
+++ b/src/anemoi/models/layers/processor.py
@@ -164,7 +164,7 @@ class TransformerProcessor(BaseProcessor):
                 model_comm_group.size() == 1 or batch_size == 1
             ), "Only batch size of 1 is supported when model is sharded accross GPUs"
 
-        (x,) = self.run_layers((x,), shape_nodes, batch_size, model_comm_group, **kwargs)
+        (x,) = self.run_layers((x,), shape_nodes, batch_size, model_comm_group)
 
         return x
 

--- a/src/anemoi/models/layers/processor.py
+++ b/src/anemoi/models/layers/processor.py
@@ -97,6 +97,7 @@ class TransformerProcessor(BaseProcessor):
         num_heads: int = 16,
         mlp_hidden_ratio: int = 4,
         dropout_p: float = 0.1,
+        layer_norm: Optional[dict] = None,
         **kwargs,
     ) -> None:
         """Initialize TransformerProcessor.
@@ -138,6 +139,7 @@ class TransformerProcessor(BaseProcessor):
             window_size=window_size,
             activation=activation,
             dropout_p=dropout_p,
+            layer_norm=layer_norm,
         )
 
         self.offload_layers(cpu_offload)
@@ -157,7 +159,7 @@ class TransformerProcessor(BaseProcessor):
                 model_comm_group.size() == 1 or batch_size == 1
             ), "Only batch size of 1 is supported when model is sharded accross GPUs"
 
-        (x,) = self.run_layers((x,), shape_nodes, batch_size, model_comm_group)
+        (x,) = self.run_layers((x,), shape_nodes, batch_size, model_comm_group, **kwargs)
 
         return x
 

--- a/src/anemoi/models/layers/utils.py
+++ b/src/anemoi/models/layers/utils.py
@@ -22,18 +22,3 @@ class CheckpointWrapper(nn.Module):
 
     def forward(self, *args, **kwargs):
         return checkpoint(self.module, *args, **kwargs, use_reentrant=False)
-
-
-class AutocastLayerNorm(nn.LayerNorm):
-    """LayerNorm that casts the output back to the input type."""
-
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-
-    def forward(self, x: Tensor) -> Tensor:
-        """Forward with explicit autocast back to the input type.
-
-        This casts the output to (b)float16 (instead of float32) when we run in mixed
-        precision.
-        """
-        return super().forward(x).type_as(x)

--- a/src/anemoi/models/layers/utils.py
+++ b/src/anemoi/models/layers/utils.py
@@ -8,7 +8,6 @@
 # nor does it submit to any jurisdiction.
 
 
-from torch import Tensor
 from torch import nn
 from torch.utils.checkpoint import checkpoint
 


### PR DESCRIPTION
This PR combines the issue https://github.com/ecmwf/anemoi-core/issues/31 with the PR https://github.com/ecmwf/anemoi-models/pull/35 by @cathalobrien.

# Describe your changes

This PR makes it possible to switch the implementation of Linear and LayerNorm kernels in the config. 

At the moment we use torch.NN implementation for many layers in Anemoi model e.g. torch.nn.layerNorm, torch.NN.linear. This has the advantage of being available out of the box with torch and portable to many systems (CPU, AMD and Nvidia GPUs). However, other layer implementations might be more efficient for certain hardware, or we might want to use a custom layer. 

This PR adds the following block to config/model/<model>.yaml:
```yaml
  layer_kernels:
    LayerNorm:
      #_target_: "transformer_engine.pytorch.LayerNorm"
      _target_: "liger_kernel.transformers.rms_norm.LigerRMSNorm"
      #_target_: "torch.nn.LayerNorm" #the default PyTorch implementation
      _partial_: True
      #Any arguments to your chosen function go here e.g.
      #bias: False
    Linear:
      #_target_: "transformer_engine.pytorch.Linear"
      _target_: "torch.nn.Linear"
      _partial_: True
```
You can pass any parameters to your new kernels in the config file, after "_partial_ : True". Hydra tries to load the desired kernel in "models/encoder_processor_decoder.py". If the desired library isn't available, torch currently will fall back to torch.nn.<kernel>.

The calls to `torch.nn` are then replaced with
```python
- self.layer_norm = nn.LayerNorm(normalized_shape=num_channels)
+ self.layer_norm = layer_kernels['LayerNorm'](normalized_shape=num_channels)
```

In the future, this syntax could be extended to replace other layers if required. More specifically, a follow up PR that includes conditional layer norm.


# Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation and docstrings to reflect the changes
- [ ]  have added tests that prove my fix is effective or that my feature works
- [ ] I have ensured that the code is still pip-installable after the changes and runs
- [x] I have not introduced new dependencies in the inference partion of the model
- [X] I have ran this on single GPU
- [X] I have ran this on multi-GPU or multi-node
- [ ] I have ran the Benchmark Profiler against the old version of the code
- [x] I've tested the changes with the Transformer, GraphTransformer and GNN